### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Mocking Mirror
 ==============
 
-* .. image:: https://pypip.in/version/mockingmirror/badge.svg?branch=master
+* .. image:: https://img.shields.io/pypi/v/mockingmirror.svg?branch=master
     :target: https://pypi.python.org/pypi/mockingmirror/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20mockingmirror))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `mockingmirror`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.